### PR TITLE
NO-ISSUE add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "wednesday"
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 20
+    reviewers:
+      - alimsanzhar
+      - oizuldan
+      - nurbekismagulov


### PR DESCRIPTION
This PR adds dependabot config. Dependabot will create PR for updating versions of our npm/yarn packages automatically, so we won't need to check for new versions of our packages manually. This will create max of 20 PRs every Wednesday. I encourage us to check for these PRs every Wednesday :)