### PR TITLE
LST-8 Setup telegram bot with grammy framework

### DIFF
--- a/packages/telegram-bot/.env.example
+++ b/packages/telegram-bot/.env.example
@@ -1,0 +1,2 @@
+# Paste token here
+TELEGRAM_TOKEN=********

--- a/packages/telegram-bot/nodemon.json
+++ b/packages/telegram-bot/nodemon.json
@@ -2,7 +2,7 @@
   "watch": ["src"],
   "ext": "ts,js,json",
   "ignore": ["coverage"],
-  "exec": "tsc && ts-node ./src/server.ts",
+  "exec": "tsc && env-cmd ts-node src/index.ts",
   "restartable": "rs",
   "env": {
     "NODE_ENV": "development"

--- a/packages/telegram-bot/package.json
+++ b/packages/telegram-bot/package.json
@@ -2,18 +2,25 @@
   "name": "@lostie/telegram-bot",
   "version": "0.0.0",
   "license": "MIT",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "rimraf ./dist && tsc",
     "dev": "nodemon",
-    "start": "yarn build && node dist/server.js",
+    "start": "yarn build && node .",
     "test": "yarn build && jest",
     "test:coverage": "yarn test -- --coverage --collectCoverageFrom=\"./src/**\"",
     "test:watch": "yarn build && jest --watch"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/node": "^18.11.18",
+    "@types/node-fetch": "^2.6.2",
+    "env-cmd": "^10.1.0",
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
+  },
+  "dependencies": {
+    "grammy": "^1.13.0"
   }
 }

--- a/packages/telegram-bot/src/index.ts
+++ b/packages/telegram-bot/src/index.ts
@@ -1,0 +1,18 @@
+import { Bot, Context } from 'grammy';
+
+const bot = new Bot(process.env.TELEGRAM_TOKEN || '');
+
+const introductionMessage = `Hello! I'm a Telegram bot.
+I'm powered by Cyclic, the next-generation serverless computing platform.
+
+<b>Commands</b>
+/yo - Be greeted by me
+/effect [text] - Show a keyboard to apply text effects to [text]`;
+
+const replyWithIntro = (ctx: Context) =>
+  ctx.reply(introductionMessage, {
+    parse_mode: 'HTML',
+  });
+
+bot.on('message', replyWithIntro);
+bot.start();

--- a/packages/telegram-bot/src/server.ts
+++ b/packages/telegram-bot/src/server.ts
@@ -1,3 +1,0 @@
-export const func = (): void => {
-  console.log('Hello world!');
-};


### PR DESCRIPTION
This PR sets up minimal telegram bot with grammy framework. Based on this [article](https://www.cyclic.sh/posts/how-to-build-a-telegram-bot/).

First of all we need to setup .env file to run telegram bot. We decided to store it locally as it stores sensitive data. Create locally **.env** file near **.env.example** file and paste all the stuff from the **.env.example** file to **.env** file and  replace *** to real token. Then run **yarn dev**.

Closes #8 